### PR TITLE
Fix copy/paste error for CrewAI Day 2 notebook

### DIFF
--- a/crewai_series/day_02.ipynb
+++ b/crewai_series/day_02.ipynb
@@ -79,7 +79,7 @@
     "            agent=agent,\n",
     "        )\n",
     "\n",
-    "    def emoji_task(self, agent):\n",
+    "    def chuck_norris_joke_picker_task(self, agent):\n",
     "        return Task(\n",
     "            description=dedent(\n",
     "                f\"\"\"\n",


### PR DESCRIPTION
The task method name was incorrect.